### PR TITLE
fix: resolve `days` flag conflict caused by shared `cli.CertConfig`

### DIFF
--- a/cmd/gen/ca/ca.go
+++ b/cmd/gen/ca/ca.go
@@ -29,7 +29,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewCmdGenCA(cfg *cli.CertConfig) *cobra.Command {
+var cfg = &cli.CertConfig{}
+
+func NewCmdGenCA() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "ca",
 		Short: "Generate a certificate authority",

--- a/cmd/gen/gen.go
+++ b/cmd/gen/gen.go
@@ -22,21 +22,20 @@ THE SOFTWARE.
 package gen
 
 import (
-	"github.com/c3b2a7/easy-ca-cli/cli"
 	cmdCA "github.com/c3b2a7/easy-ca-cli/cmd/gen/ca"
 	cmdTLS "github.com/c3b2a7/easy-ca-cli/cmd/gen/tls"
 	"github.com/spf13/cobra"
 )
 
-func NewGenCmd(cfg *cli.CertConfig) *cobra.Command {
+func NewGenCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "gen [<command>]",
 		Short: "Generate certificates",
 		Long:  "Generate a certificate with your specified params",
 	}
 
-	cmd.AddCommand(cmdCA.NewCmdGenCA(cfg))
-	cmd.AddCommand(cmdTLS.NewCmdGenTLS(cfg))
+	cmd.AddCommand(cmdCA.NewCmdGenCA())
+	cmd.AddCommand(cmdTLS.NewCmdGenTLS())
 
 	return cmd
 }

--- a/cmd/gen/tls/tls.go
+++ b/cmd/gen/tls/tls.go
@@ -33,13 +33,13 @@ import (
 )
 
 type tlsConfig struct {
-	*cli.CertConfig
+	cli.CertConfig
 	Host string
 }
 
-func NewCmdGenTLS(cfg *cli.CertConfig) *cobra.Command {
-	tlsCfg := &tlsConfig{CertConfig: cfg}
+var tlsCfg = &tlsConfig{}
 
+func NewCmdGenTLS() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tls",
 		Short: "Generate a tls certificate",
@@ -49,8 +49,8 @@ func NewCmdGenTLS(cfg *cli.CertConfig) *cobra.Command {
 		},
 	}
 
-	flags.ApplyCommonFlags(cmd, cfg)
-	cmd.Flags().IntVar(&cfg.Days, "days", 825, "days that certificate is valid for")
+	flags.ApplyCommonFlags(cmd, &tlsCfg.CertConfig)
+	cmd.Flags().IntVar(&tlsCfg.CertConfig.Days, "days", 825, "days that certificate is valid for")
 	cmd.Flags().StringVar(&tlsCfg.Host, "host", "", "comma-separated hostnames and IPs to generate a certificate for")
 
 	return cmd
@@ -87,5 +87,5 @@ func runGenTLS(cfg *tlsConfig) error {
 	}
 
 	issuerCertificateChain := cli.Must(cfg.IssuerCertificateChain()).([]*x509.Certificate)
-	return cli.Out(cfg.CertConfig, append([]*x509.Certificate{certificate}, issuerCertificateChain...), keyPair)
+	return cli.Out(&cfg.CertConfig, append([]*x509.Certificate{certificate}, issuerCertificateChain...), keyPair)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,18 +22,18 @@ THE SOFTWARE.
 package cmd
 
 import (
-	"github.com/c3b2a7/easy-ca-cli/cli"
 	"github.com/c3b2a7/easy-ca-cli/cmd/gen"
 	"github.com/spf13/cobra"
 )
 
-var cfg cli.CertConfig
-
 var rootCmd = &cobra.Command{
 	Use:   "easy-ca-cli",
-	Short: "easy-ca-cli is a very simple certificate generator",
-	Long: `A simple and easy to use certificate generator built with love by c3b2a in Go.
-Complete documentation is available at https://github.com/c3b2a7/easy-ca-cli#usage`,
+	Short: "easy-ca-cli is a certificate generator",
+	Long: `The easy-ca-cli is a fast, simple certificate generation utility built in Go.
+It serves as a CLI to the core [easy-ca](https://github.com/c3b2a7/easy-ca) library,
+providing an accessible way to generate various certificate types with customizable parameters.
+
+Complete documentation is available at https://github.com/c3b2a7/easy-ca-cli#easy-ca-cli`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
@@ -46,5 +46,5 @@ func Execute() {
 }
 
 func init() {
-	rootCmd.AddCommand(gen.NewGenCmd(&cfg))
+	rootCmd.AddCommand(gen.NewGenCmd())
 }


### PR DESCRIPTION
When multiple commands reuse cli.CertConfig, the 'days' flag is registered multiple times, causing a conflict at runtime. This change ensures each command has its own properly scoped flag configuration to avoid duplication.

Fixes #11 