### PR TITLE
chore: ignore generated files to avoid dirty git state in CI

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Syft version
         run: syft version
       - run: |
-          cat > CHANGELOG.md <<'EOF'
+          cat > RELEASE_NOTES.md <<'EOF'
           ${{ needs.generate-changelog.outputs.content }}
           EOF
       - name: Login to GitHub Container Registry
@@ -108,7 +108,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: '~> v2'
-          args: release --clean --release-notes=CHANGELOG.md
+          args: release --clean --release-notes=RELEASE_NOTES.md
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 
 bin/
 dist/
+
+RELEASE_NOTES.md


### PR DESCRIPTION
- rename CHANGELOG.md to RELEASE_NOTES.md
- add RELEASE_NOTES.md to .gitignore to prevent untracked changes during goreleaser builds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the release pipeline to publish notes from RELEASE_NOTES.md instead of CHANGELOG.md. The content of the notes remains unchanged.
  - Added RELEASE_NOTES.md to .gitignore to prevent committing generated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->